### PR TITLE
#CP13 Create Reset Password pages (CRUD)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7245,20 +7245,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -20709,13 +20695,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "format": "npx pretty-quick",
     "lint": "npx eslint src/*.j{s,sx} --fix",
-    "test": "jest",
+    "test": "jest --watch",
     "coverage": "jest --coverage",
     "testPro": "cd dist && http-server"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,24 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import './app.css';
 import Footer from './components/Footer.js';
 import Header from './components/Header.js';
+import SkeletonScreen from './components/SkeletonScreen.js';
 import Account from './pages/Account.js';
+import AccountRouter from './pages/accounts/AccountRouter.js';
 import LandingPage from './pages/LandingPage.js';
 import Login from './pages/Login.js';
 import { store } from './redux/store.js';
 import { useLoader } from './useLoader.js';
-import SkeletonScreen from './components/SkeletonScreen.js';
 
 function App() {
   const { loading } = useLoader();
 
   return (
-    <div className="App flex flex-col">
+    <div className="App min-h-screen h-full">
       {loading && <SkeletonScreen />}
       {!loading && (
         <div>
@@ -26,9 +29,15 @@ function App() {
                 <Route path="/" element={<LandingPage />} />
                 <Route path="/login" element={<Login />} />
                 <Route path="/account" element={<Account />} />
+                <Route
+                  exact={false}
+                  path="/accounts/*"
+                  element={<AccountRouter />}
+                />
               </Routes>
               <Footer />
             </BrowserRouter>
+            <ToastContainer theme="colored" />
           </Provider>
         </div>
       )}

--- a/src/components/SkeletonScreen.js
+++ b/src/components/SkeletonScreen.js
@@ -22,7 +22,7 @@ const SkeletonScreen = () => {
           </h2>
           <div className="w-28 md:w-28 lg:w-28 xl:w-28 bg-gray-300 h-10 rounded-3xl mt-12 px-12 xl:px-12 py-2" />
         </section>
-        <div className="w-64 md:w-96 lg:w-96 xl:w-96 h-32 mb-8 md:h-48 lg:h-48 xl:h-48 rounded-xl bg-gray-300 px-20 lg:w-80 xl:w-96 lg:ml-auto xl:ml-auto lg:mr-36 xl:mr-36 mt-28" />
+        <div className="w-64 md:w-96 lg:w-96 h-32 mb-8 md:h-48 lg:h-48 xl:h-48 rounded-xl bg-gray-300 px-20  xl:w-96 lg:ml-auto xl:ml-auto lg:mr-36 xl:mr-36 mt-28" />
       </main>
     </div>
   );

--- a/src/components/tests/__snapshots__/SkeletonScreen.test.js.snap
+++ b/src/components/tests/__snapshots__/SkeletonScreen.test.js.snap
@@ -48,7 +48,7 @@ exports[`SkeletonScreen should render SkeletonScreen 1`] = `
       />
     </section>
     <div
-      className="w-64 md:w-96 lg:w-96 xl:w-96 h-32 mb-8 md:h-48 lg:h-48 xl:h-48 rounded-xl bg-gray-300 px-20 lg:w-80 xl:w-96 lg:ml-auto xl:ml-auto lg:mr-36 xl:mr-36 mt-28"
+      className="w-64 md:w-96 lg:w-96 h-32 mb-8 md:h-48 lg:h-48 xl:h-48 rounded-xl bg-gray-300 px-20  xl:w-96 lg:ml-auto xl:ml-auto lg:mr-36 xl:mr-36 mt-28"
     />
   </main>
 </div>

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import busMapImg from '../assets/busMap.png';
 
@@ -89,9 +89,12 @@ const Login = () => {
             <p className="text-red-600 text-sm">
               {errors?.password && errors.password.message}
             </p>
-            <h4 className="text-primary text-right mb-5 text-sm font-bold">
-              Forgot password?
-            </h4>
+            <Link to="/accounts/reset-password">
+              <h4 className="text-primary text-right mb-5 text-sm font-bold">
+                Forgot password?
+              </h4>
+            </Link>
+
             {attempts > 5 ? (
               <button
                 disabled

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+function NotFound() {
+  return (
+    <div className="flex items-center flex-col justify-center h-screen">
+      <h1 className="text-bold text-3xl font-rale">Oops. Page Not Found</h1>
+      <Link
+        to="/"
+        className="py-1 px-2 bg-primary hover:bg-hover font-bold rounded-md my-3 text-white"
+      >
+        Back Home
+      </Link>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/pages/accounts/AccountRouter.js
+++ b/src/pages/accounts/AccountRouter.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import ResetFormPage from './EmailForm.js';
+import ResetEmail from './EmailSent.js';
+import ResetNewPassword from './NewPasswordForm.js';
+import NotFoundAccount from './NotFound.js';
+import ResetSuccess from './PasswordChanged.js';
+const img =
+  'https://res.cloudinary.com/feyton/image/upload/v1645616111/Codebandits/Phantom_icon_1_tpjkws.png';
+const phantom =
+  'https://res.cloudinary.com/feyton/image/upload/v1645611696/Codebandits/phantom_lkpwx7.png';
+const codebandits =
+  'https://res.cloudinary.com/feyton/image/upload/v1644861999/Codebandits/codebandits_favicon_ahnxce.png';
+export const Button = ({ name, styles, type, icon }) => {
+  return (
+    <div>
+      <button
+        type={type || 'button'}
+        className={`rounded-md transition-all text-white py-1 px-5 mt-2 ${
+          icon == 'cancel' ? 'bg-red-500' : 'bg-primary'
+        } hover:bg-hover hover:transition-all font-bold ${styles}`}
+      >
+        {name}
+      </button>
+    </div>
+  );
+};
+
+function ResetRouterLayout() {
+  return (
+    <>
+      <>
+        <div className="min-h-[75vh] h-full flex flex-col pb-40 md:pb-2 relative py-4 md:flex-row items-center justify-center">
+          <div className="max-w-sm mr-10 mt-[-60px] md:flex md:items-center md:justify-center md:mx-auto md:my-[auto] xl:ml-64">
+            <img
+              src={img}
+              alt="placeholder-img"
+              className="w-full object-cover"
+            />
+          </div>
+
+          <div className="flex flex-col  py-3 px-4 w-72 md:w-80 md:min-w-[300px] md:max-w-sm shadow-main absolute bg-white top-16 md:top-0 md:mx-auto md:relative rounded-lg xl:mr-64">
+            <Routes>
+              <Route path="reset-password" element={<ResetFormPage />} />
+              <Route
+                path="reset-success"
+                element={<ResetSuccess></ResetSuccess>}
+              ></Route>
+              <Route
+                path="reset-password/:uuid/:token"
+                element={<ResetNewPassword></ResetNewPassword>}
+              ></Route>
+              <Route
+                path="reset-email/:uuid/:token"
+                element={<ResetEmail />}
+              ></Route>
+              <Route path="*" element={<NotFoundAccount />}></Route>
+            </Routes>
+          </div>
+        </div>
+      </>
+    </>
+  );
+}
+
+export default ResetRouterLayout;

--- a/src/pages/accounts/EmailForm.js
+++ b/src/pages/accounts/EmailForm.js
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import sleep from '../../utils/sleep.js';
+import { Button } from './AccountRouter.js';
+
+const img =
+  'https://res.cloudinary.com/feyton/image/upload/v1645616111/Codebandits/Phantom_icon_1_tpjkws.png';
+const EM_RGX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+
+function ResetFormPage() {
+  let navigate = useNavigate();
+  const [loading, setloading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm({
+    reValidateMode: 'onChange',
+    mode: 'onChange'
+  });
+
+  const handleEmail = (email) => {
+    if (email == 'fab@me.com') {
+      sleep(3000).then(() => {
+        toast('You account was found');
+        navigate('/accounts/reset-email/abcd-1234-ghyi-567/123456');
+      });
+    } else {
+      sleep(3000, 'reject')
+        .then(() => {})
+        .catch(() => {
+          setloading(false);
+          toast('Account not found', {
+            theme: 'colored',
+            type: 'error'
+          });
+        });
+    }
+  };
+
+  const onSubmit = (data) => {
+    setloading(true);
+    handleEmail(data.email);
+  };
+
+  return (
+    <>
+      <h3 className="text-2xl font-bold text-center py-3 font-rale">
+        RESET PASSWORD
+      </h3>
+      <p className="mb-3 text-sm">
+        Enter your email to receive a password reset link
+      </p>
+      <form id="form" onSubmit={handleSubmit(onSubmit)} role={'form'}>
+        <div className="relative w-full">
+          <label
+            htmlFor="email"
+            className="block font-bold mb-2 focus:outline-none required"
+          >
+            Email:
+          </label>
+          <input
+            name="email"
+            type="email"
+            id="email"
+            placeholder="Your email"
+            {...register('email', {
+              required: 'Email is required',
+              pattern: {
+                value: EM_RGX,
+                message: 'Invalid email'
+              }
+            })}
+            className={`block w-full rounded-md border-2 placeholder:text-gray-400 placeholder:text-small py-1 px-3 focus:outline-none ${
+              !errors?.email ? 'border-green-500' : ''
+            } ${errors?.email ? 'border-red-500' : ''}`}
+          />
+          {
+            <p
+              role={'alert'}
+              className={`text-sm text-red-900 font-bold py-1/2 pl-2 ${
+                errors?.email ? 'opacity-100' : 'opacity-0'
+              }`}
+            >
+              {errors?.email && errors.email.message}
+            </p>
+          }
+        </div>
+        <div className="flex flex-row justify-between mt-2">
+          <Button name={loading ? 'SENDING...' : 'SUBMIT'} type={'submit'} />
+          <Link to="/">
+            <Button
+              name={'CANCEL'}
+              type={'button'}
+              icon={'cancel'}
+              styles={'hover:bg-hovercancel hover:transition-all'}
+            />
+          </Link>
+        </div>
+      </form>
+    </>
+  );
+}
+
+export default ResetFormPage;

--- a/src/pages/accounts/EmailSent.js
+++ b/src/pages/accounts/EmailSent.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+const img =
+  'https://cdn.pixabay.com/photo/2012/04/18/19/01/check-37583_960_720.png';
+
+function EmailSent() {
+  const { uuid, token } = useParams();
+
+  return (
+    <>
+      <h3 className="text-2xl font-rale mb-2 text-center font-bold">
+        Email Sent
+      </h3>
+      <img src={img} alt="" className="h-24  mx-auto mt-4" />
+
+      <div className="text-left mt-4">
+        <p className="mb-2 text-justify text-sm">
+          A link to reset your password has been sent to <b>"fab@me.com"</b>
+        </p>
+
+        <p className=" text-justify text-sm">
+          Did not receive the email? Remember to check <b>Junk/Spam</b> folder
+        </p>
+      </div>
+      <div className="bg-yellow-300 rounded-md text-xs p-2 font-bold">
+        <Link
+          className="text-primary my-2"
+          to={`/accounts/reset-password/${uuid}/${token}`}
+        >
+          Test
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default EmailSent;

--- a/src/pages/accounts/NewPasswordForm.js
+++ b/src/pages/accounts/NewPasswordForm.js
@@ -1,0 +1,121 @@
+import React, { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import sleep from '../../utils/sleep.js';
+
+function ResetNewPassword() {
+  const PASS_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).{6,}$/;
+  let navigate = useNavigate();
+  const [valid, setValid] = useState(false);
+  const [loading, setloading] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch
+  } = useForm({
+    reValidateMode: 'onChange',
+    mode: 'onChange'
+  });
+  const password = useRef({});
+  password.current = watch('password', '');
+  const pass2 = useRef({});
+  watch('password2', '');
+
+  const onValid = (data) => {
+    setloading(true);
+    setValid(true);
+    sleep(2000).then(() => {
+      setloading(false);
+      toast('Your new password has been created', {
+        theme: 'colored',
+        type: 'success'
+      });
+
+      navigate('/accounts/reset-success');
+    });
+  };
+  const onErrors = (errors) => {
+    setValid(false);
+  };
+  return (
+    <>
+      <form onSubmit={handleSubmit(onValid, onErrors)}>
+        <h3 className="text-2xl font-bold font-rale text-center py-4">
+          New Password
+        </h3>
+
+        <div className="relative w-full">
+          <label htmlFor="password" className="font-bold text-sm">
+            Password <span className="text-red-500 font-bold">*</span>:{' '}
+          </label>
+          <input
+            type="Password"
+            ref={password}
+            placeholder="New password"
+            id="password"
+            name="password"
+            {...register('password', {
+              required: 'New password required',
+              pattern: {
+                value: PASS_REGEX,
+                message:
+                  'Must have an uppercase, lowercase, number and be at least 6 chars'
+              }
+            })}
+            required
+            className={`w-full rounded-md placeholder:text-sm placeholder:font-light ${
+              !errors?.password ? '' : ' border-gray-400 '
+            } border-2 focus:outline-none px-2 py-1 font-bold ${
+              !errors?.password ? ' border-green-500' : ' '
+            } ${errors?.password ? 'border-red-500' : ''}`}
+          />
+          <div
+            className={`text-xs py-1/2 text-red-500 ${
+              errors?.password ? 'opacity-100' : 'opacity-0'
+            }`}
+          >
+            {(errors?.password && errors.password.message) || ''}
+          </div>
+        </div>
+        <div className="relative w-full mb-2">
+          <label htmlFor="password2" className="font-bold text-sm">
+            Confirm password <span className="text-red-500 font-bold">*</span>:
+          </label>
+          <input
+            type="password"
+            id="password2"
+            ref={pass2}
+            name="password2"
+            placeholder="Confirm password"
+            required
+            {...register('password2', {
+              validate: (value) =>
+                value === password.current || 'The passwords do not match'
+            })}
+            className={`w-full rounded-md placeholder:text-sm placeholder:font-light ${
+              !errors?.password2 ? '' : 'border-gray-400'
+            } border-2 focus:outline-none px-2 py-1 font-bold 
+              ${!errors?.password2 ? 'border-green-500' : ''} ${
+              errors?.password2 ? 'border-red-500' : ''
+            }
+              `}
+          />
+          <div
+            className={`text-xs py-1/2 text-red-500 ${
+              errors?.password2 ? 'opacity-100' : 'opacity-0'
+            }`}
+          >
+            {(errors?.password2 && errors.password2.message) || ''}
+          </div>
+        </div>
+        <button className="py-1 px-3 text-center bg-primary hover:bg-hover transition-all hover:transition-all uppercase text-white font-bold rounded-md">
+          {loading ? 'SENDING...' : 'SUBMIT'}
+        </button>
+      </form>
+    </>
+  );
+}
+
+export default ResetNewPassword;

--- a/src/pages/accounts/NotFound.js
+++ b/src/pages/accounts/NotFound.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from './AccountRouter.js';
+
+function NotFoundAccount() {
+  return (
+    <>
+      <div className="w-fit flex flex-col justify-center items-center p-3">
+        <h3 className="text-3xl font-bold pb-4">Oops... Not Found</h3>
+        <Link to="/">
+          <Button name={'Home'} styles={' bg-primary mt-2'}></Button>
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default NotFoundAccount;

--- a/src/pages/accounts/PasswordChanged.js
+++ b/src/pages/accounts/PasswordChanged.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function PasswordChanged() {
+  return (
+    <>
+      <h3 className="text-2xl text-center font-rale font-bold mb-2">
+        Password Changed
+      </h3>
+      <hr />
+      <div className="text-left">
+        <p className="py-1 mb-2  text-sm">
+          Dear <b>Fabrice</b>, you got yourself a new password.
+        </p>
+        <Link
+          to="/login"
+          className="py-1 px-3  bg-primary hover:bg-hover text-white rounded-md font-bold mt-5 mx-auto"
+        >
+          Login
+        </Link>
+
+        <p className="py-1 mt-2 text-sm">
+          You will receive email confirming your changes.
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default PasswordChanged;

--- a/src/pages/tests/ResetPass.test.js
+++ b/src/pages/tests/ResetPass.test.js
@@ -1,0 +1,261 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import renderer, { act } from 'react-test-renderer';
+import ResetRouterLayout from '../accounts/AccountRouter.js';
+import ResetFormPage from '../accounts/EmailForm.js';
+import EmailSent from '../accounts/EmailSent.js';
+import ResetNewPassword from '../accounts/NewPasswordForm.js';
+import PasswordChanged from '../accounts/PasswordChanged.js';
+import NotFound from '../NotFound.js';
+
+const mockHandleEmail = jest.fn((email) => {
+  return Promise.resolve(email);
+});
+
+const wrapper = shallow(
+  <BrowserRouter>
+    <ResetRouterLayout />
+  </BrowserRouter>
+);
+
+describe('Reset page layout', () => {
+  it('Render without crashing', () => {
+    expect(wrapper.length).toEqual(1);
+  });
+});
+
+describe('Reset password layout', () => {
+  it('should render all routes', () => {
+    const elem = renderer
+      .create(
+        <BrowserRouter>
+          <ResetRouterLayout />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(elem).toMatchSnapshot();
+  });
+  it('should render the new password form', () => {
+    const elem = renderer
+      .create(
+        <BrowserRouter>
+          <ResetNewPassword />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(elem).toMatchSnapshot();
+  });
+  it('should render the email sent notification', () => {
+    const elem = renderer
+      .create(
+        <BrowserRouter>
+          <EmailSent />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(elem).toMatchSnapshot();
+  });
+  it('should render the email Form', () => {
+    const elem = renderer
+      .create(
+        <BrowserRouter>
+          <ResetNewPassword />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(elem).toMatchSnapshot();
+  });
+  // it('should render the errors', async () => {
+  //   await act(async () => {
+  //     const handleSubmitMock = jest.fn();
+  //     const elem = mount(
+  //       <BrowserRouter>
+  //         <ResetFormPage handleSubmit={handleSubmitMock()} />
+  //       </BrowserRouter>
+  //     );
+  //     elem.simulate('change', { target: { name: 'email', value: 'fab' } });
+  //     elem.find('form').simulate('submit');
+  //     expect(elem).toMatchSnapshot();
+  //   });
+  // });
+  it('should render the success message', () => {
+    const elem = renderer
+      .create(
+        <BrowserRouter>
+          <PasswordChanged />
+        </BrowserRouter>
+      )
+      .toJSON();
+    expect(elem).toMatchSnapshot();
+  });
+});
+
+// describe('Actions and branches', () => {
+//   it('should return errors', async () => {
+//     act(async () => {
+//       const handleSubmitMock = jest.fn();
+//       const elem = mount(
+//         <BrowserRouter>
+//           <ResetNewPassword handleSubmit={handleSubmitMock()} />
+//         </BrowserRouter>
+//       );
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password',
+//           value: '123'
+//         }
+//       });
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password2',
+//           value: '1234'
+//         }
+//       });
+//       elem.find('form').simulate('submit');
+//       expect(elem).toMatchSnapshot();
+//     });
+//   });
+//   it('should return errors', () => {
+//     const handleSubmitMock = jest.fn();
+//     const elem = mount(
+//       <BrowserRouter>
+//         <ResetNewPassword handleSubmit={handleSubmitMock()} />
+//       </BrowserRouter>
+//     );
+//     act(() => {
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password',
+//           value: '123'
+//         }
+//       });
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password2',
+//           value: '1234'
+//         }
+//       });
+//       elem.find('form').simulate('submit');
+//     });
+//     expect(elem).toMatchSnapshot();
+//     expect(handleSubmitMock).toBeCalled();
+//   });
+//   it('should return success', async () => {
+//     const handleSubmitMock = jest.fn();
+//     const onValid = jest.fn();
+
+//     await act(async () => {
+//       const elem = mount(
+//         <BrowserRouter>
+//           <ResetNewPassword
+//             onValid={onValid()}
+//             handleSubmit={handleSubmitMock()}
+//           />
+//         </BrowserRouter>
+//       );
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password',
+//           value: 'Fab123'
+//         }
+//       });
+//       elem.simulate('change', {
+//         target: {
+//           name: 'password2',
+//           value: 'Fab123'
+//         }
+//       });
+//       elem.find('form').simulate('submit');
+//       expect(elem).toMatchSnapshot();
+//       expect(handleSubmitMock).toBeCalled();
+//       expect(onValid).toBeCalled();
+//     });
+//   });
+// });
+
+describe('NotFound', () => {
+  it('It renders without', () => {
+    const elem = renderer.create(
+      <BrowserRouter>
+        <NotFound></NotFound>
+      </BrowserRouter>
+    );
+    expect(elem).toMatchSnapshot();
+  });
+});
+
+describe('Testing Library', () => {
+  beforeEach(() => {
+    render(
+      <BrowserRouter>
+        <ResetFormPage handleEmail={mockHandleEmail} />
+      </BrowserRouter>
+    );
+  });
+  it('Should display required error when email is invalid', async () => {
+    fireEvent.submit(screen.getByTestId('form'));
+    expect(await screen.getAllByRole('alert')).toHaveLength(1);
+    expect(mockHandleEmail).not.toBeCalled();
+  });
+  it('Should display an invalid email error', async () => {
+    fireEvent.input(screen.getByRole('textbox', { name: /email/i }), {
+      target: {
+        value: 'test'
+      }
+    });
+    fireEvent.submit(screen.getByTestId('form'));
+    expect(await screen.findAllByRole('alert')).toHaveLength(1);
+    expect(await screen.findAllByText('Invalid email')).toHaveLength(1);
+  });
+  it('Should submit the form when email is valid', async () => {
+    fireEvent.input(screen.getByRole('textbox', { name: /email/i }), {
+      target: {
+        value: 'fab@me.com'
+      }
+    });
+    fireEvent.submit(screen.getByTestId('form'));
+    expect(await screen.findAllByText('SENDING...')).toHaveLength(1);
+  });
+});
+
+
+describe('function testing', () => {
+  let wrapper;
+
+  it('Should return a errors', async () => {
+    await act(async () => {
+      wrapper = mount(
+        <BrowserRouter>
+          <ResetFormPage handleEmail={mockHandleEmail} />
+        </BrowserRouter>
+      );
+      wrapper.find('form').simulate('submit');
+      expect(await wrapper).toMatchSnapshot();
+    });
+  });
+  it('Should return a errors in new password', async () => {
+    await act(async () => {
+      wrapper = mount(
+        <BrowserRouter>
+          <ResetNewPassword handleEmail={mockHandleEmail} />
+        </BrowserRouter>
+      );
+      wrapper.simulate('change', {
+        target: {
+          name: 'password',
+          value: '123'
+        }
+      });
+      wrapper.simulate('change', {
+        target: {
+          name: 'password2',
+          value: '123'
+        }
+      });
+      wrapper.find('form').simulate('submit');
+      expect(await wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/src/pages/tests/__snapshots__/Login.test.js.snap
+++ b/src/pages/tests/__snapshots__/Login.test.js.snap
@@ -71,11 +71,16 @@ exports[`Login snapshot test should render Login 1`] = `
         <p
           className="text-red-600 text-sm"
         />
-        <h4
-          className="text-primary text-right mb-5 text-sm font-bold"
+        <a
+          href="/accounts/reset-password"
+          onClick={[Function]}
         >
-          Forgot password?
-        </h4>
+          <h4
+            className="text-primary text-right mb-5 text-sm font-bold"
+          >
+            Forgot password?
+          </h4>
+        </a>
         <button
           className="bg-primary px-5 py-2 rounded-md text-white w-fit mx-auto hover:bg-hover transition-all hover:transition-all"
           id="login-btn"

--- a/src/pages/tests/__snapshots__/ResetPass.test.js.snap
+++ b/src/pages/tests/__snapshots__/ResetPass.test.js.snap
@@ -1,0 +1,548 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFound It renders without 1`] = `
+<div
+  className="flex items-center flex-col justify-center h-screen"
+>
+  <h1
+    className="text-bold text-3xl font-rale"
+  >
+    Oops. Page Not Found
+  </h1>
+  <a
+    className="py-1 px-2 bg-primary hover:bg-hover font-bold rounded-md my-3 text-white"
+    href="/"
+    onClick={[Function]}
+  >
+    Back Home
+  </a>
+</div>
+`;
+
+exports[`Reset password layout should render all routes 1`] = `
+<div
+  className="min-h-[75vh] h-full flex flex-col pb-40 md:pb-2 relative py-4 md:flex-row items-center justify-center"
+>
+  <div
+    className="max-w-sm mr-10 mt-[-60px] md:flex md:items-center md:justify-center md:mx-auto md:my-[auto] xl:ml-64"
+  >
+    <img
+      alt="placeholder-img"
+      className="w-full object-cover"
+      src="https://res.cloudinary.com/feyton/image/upload/v1645616111/Codebandits/Phantom_icon_1_tpjkws.png"
+    />
+  </div>
+  <div
+    className="flex flex-col  py-3 px-4 w-72 md:w-80 md:min-w-[300px] md:max-w-sm shadow-main absolute bg-white top-16 md:top-0 md:mx-auto md:relative rounded-lg xl:mr-64"
+  >
+    <div
+      className="w-fit flex flex-col justify-center items-center p-3"
+    >
+      <h3
+        className="text-3xl font-bold pb-4"
+      >
+        Oops... Not Found
+      </h3>
+      <a
+        href="/"
+        onClick={[Function]}
+      >
+        <div>
+          <button
+            className="rounded-md transition-all text-white py-1 px-5 mt-2 bg-primary hover:bg-hover hover:transition-all font-bold  bg-primary mt-2"
+            type="button"
+          >
+            Home
+          </button>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Reset password layout should render the email Form 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <h3
+    className="text-2xl font-bold font-rale text-center py-4"
+  >
+    New Password
+  </h3>
+  <div
+    className="relative w-full"
+  >
+    <label
+      className="font-bold text-sm"
+      htmlFor="password"
+    >
+      Password 
+      <span
+        className="text-red-500 font-bold"
+      >
+        *
+      </span>
+      :
+       
+    </label>
+    <input
+      className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold  border-green-500 "
+      id="password"
+      name="password"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="New password"
+      required={true}
+      type="Password"
+    />
+    <div
+      className="text-xs py-1/2 text-red-500 opacity-0"
+    >
+      
+    </div>
+  </div>
+  <div
+    className="relative w-full mb-2"
+  >
+    <label
+      className="font-bold text-sm"
+      htmlFor="password2"
+    >
+      Confirm password 
+      <span
+        className="text-red-500 font-bold"
+      >
+        *
+      </span>
+      :
+    </label>
+    <input
+      className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold 
+              border-green-500 
+              "
+      id="password2"
+      name="password2"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="Confirm password"
+      required={true}
+      type="password"
+    />
+    <div
+      className="text-xs py-1/2 text-red-500 opacity-0"
+    >
+      
+    </div>
+  </div>
+  <button
+    className="py-1 px-3 text-center bg-primary hover:bg-hover transition-all hover:transition-all uppercase text-white font-bold rounded-md"
+  >
+    SUBMIT
+  </button>
+</form>
+`;
+
+exports[`Reset password layout should render the email sent notification 1`] = `
+Array [
+  <h3
+    className="text-2xl font-rale mb-2 text-center font-bold"
+  >
+    Email Sent
+  </h3>,
+  <img
+    alt=""
+    className="h-24  mx-auto mt-4"
+    src="https://cdn.pixabay.com/photo/2012/04/18/19/01/check-37583_960_720.png"
+  />,
+  <div
+    className="text-left mt-4"
+  >
+    <p
+      className="mb-2 text-justify text-sm"
+    >
+      A link to reset your password has been sent to 
+      <b>
+        "fab@me.com"
+      </b>
+    </p>
+    <p
+      className=" text-justify text-sm"
+    >
+      Did not receive the email? Remember to check 
+      <b>
+        Junk/Spam
+      </b>
+       folder
+    </p>
+  </div>,
+  <div
+    className="bg-yellow-300 rounded-md text-xs p-2 font-bold"
+  >
+    <a
+      className="text-primary my-2"
+      href="/accounts/reset-password/undefined/undefined"
+      onClick={[Function]}
+    >
+      Test
+    </a>
+  </div>,
+]
+`;
+
+exports[`Reset password layout should render the new password form 1`] = `
+<form
+  onSubmit={[Function]}
+>
+  <h3
+    className="text-2xl font-bold font-rale text-center py-4"
+  >
+    New Password
+  </h3>
+  <div
+    className="relative w-full"
+  >
+    <label
+      className="font-bold text-sm"
+      htmlFor="password"
+    >
+      Password 
+      <span
+        className="text-red-500 font-bold"
+      >
+        *
+      </span>
+      :
+       
+    </label>
+    <input
+      className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold  border-green-500 "
+      id="password"
+      name="password"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="New password"
+      required={true}
+      type="Password"
+    />
+    <div
+      className="text-xs py-1/2 text-red-500 opacity-0"
+    >
+      
+    </div>
+  </div>
+  <div
+    className="relative w-full mb-2"
+  >
+    <label
+      className="font-bold text-sm"
+      htmlFor="password2"
+    >
+      Confirm password 
+      <span
+        className="text-red-500 font-bold"
+      >
+        *
+      </span>
+      :
+    </label>
+    <input
+      className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold 
+              border-green-500 
+              "
+      id="password2"
+      name="password2"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="Confirm password"
+      required={true}
+      type="password"
+    />
+    <div
+      className="text-xs py-1/2 text-red-500 opacity-0"
+    >
+      
+    </div>
+  </div>
+  <button
+    className="py-1 px-3 text-center bg-primary hover:bg-hover transition-all hover:transition-all uppercase text-white font-bold rounded-md"
+  >
+    SUBMIT
+  </button>
+</form>
+`;
+
+exports[`Reset password layout should render the success message 1`] = `
+Array [
+  <h3
+    className="text-2xl text-center font-rale font-bold mb-2"
+  >
+    Password Changed
+  </h3>,
+  <hr />,
+  <div
+    className="text-left"
+  >
+    <p
+      className="py-1 mb-2  text-sm"
+    >
+      Dear 
+      <b>
+        Fabrice
+      </b>
+      , you got yourself a new password.
+    </p>
+    <a
+      className="py-1 px-3  bg-primary hover:bg-hover text-white rounded-md font-bold mt-5 mx-auto"
+      href="/login"
+      onClick={[Function]}
+    >
+      Login
+    </a>
+    <p
+      className="py-1 mt-2 text-sm"
+    >
+      You will receive email confirming your changes.
+    </p>
+  </div>,
+]
+`;
+
+exports[`function testing Should return a errors 1`] = `
+<BrowserRouter>
+  <Router
+    location={
+      Object {
+        "hash": "",
+        "key": "default",
+        "pathname": "/",
+        "search": "",
+        "state": null,
+      }
+    }
+    navigationType="POP"
+    navigator={
+      Object {
+        "action": "POP",
+        "back": [Function],
+        "block": [Function],
+        "createHref": [Function],
+        "forward": [Function],
+        "go": [Function],
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "key": "default",
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <ResetFormPage
+      handleEmail={[MockFunction]}
+    >
+      <h3
+        className="text-2xl font-bold text-center py-3 font-rale"
+      >
+        RESET PASSWORD
+      </h3>
+      <p
+        className="mb-3 text-sm"
+      >
+        Enter your email to receive a password reset link
+      </p>
+      <form
+        id="form"
+        onSubmit={[Function]}
+        role="form"
+      >
+        <div
+          className="relative w-full"
+        >
+          <label
+            className="block font-bold mb-2 focus:outline-none required"
+            htmlFor="email"
+          >
+            Email:
+          </label>
+          <input
+            className="block w-full rounded-md border-2 placeholder:text-gray-400 placeholder:text-small py-1 px-3 focus:outline-none border-green-500 "
+            id="email"
+            name="email"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="Your email"
+            type="email"
+          />
+          <p
+            className="text-sm text-red-900 font-bold py-1/2 pl-2 opacity-0"
+            role="alert"
+          />
+        </div>
+        <div
+          className="flex flex-row justify-between mt-2"
+        >
+          <Button
+            name="SUBMIT"
+            type="submit"
+          >
+            <div>
+              <button
+                className="rounded-md transition-all text-white py-1 px-5 mt-2 bg-primary hover:bg-hover hover:transition-all font-bold undefined"
+                type="submit"
+              >
+                SUBMIT
+              </button>
+            </div>
+          </Button>
+          <Link
+            to="/"
+          >
+            <a
+              href="/"
+              onClick={[Function]}
+            >
+              <Button
+                icon="cancel"
+                name="CANCEL"
+                styles="hover:bg-hovercancel hover:transition-all"
+                type="button"
+              >
+                <div>
+                  <button
+                    className="rounded-md transition-all text-white py-1 px-5 mt-2 bg-red-500 hover:bg-hover hover:transition-all font-bold hover:bg-hovercancel hover:transition-all"
+                    type="button"
+                  >
+                    CANCEL
+                  </button>
+                </div>
+              </Button>
+            </a>
+          </Link>
+        </div>
+      </form>
+    </ResetFormPage>
+  </Router>
+</BrowserRouter>
+`;
+
+exports[`function testing Should return a errors in new password 1`] = `
+<BrowserRouter>
+  <Router
+    location={
+      Object {
+        "hash": "",
+        "key": "default",
+        "pathname": "/",
+        "search": "",
+        "state": null,
+      }
+    }
+    navigationType="POP"
+    navigator={
+      Object {
+        "action": "POP",
+        "back": [Function],
+        "block": [Function],
+        "createHref": [Function],
+        "forward": [Function],
+        "go": [Function],
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "key": "default",
+          "pathname": "/",
+          "search": "",
+          "state": null,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <ResetNewPassword
+      handleEmail={[MockFunction]}
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <h3
+          className="text-2xl font-bold font-rale text-center py-4"
+        >
+          New Password
+        </h3>
+        <div
+          className="relative w-full"
+        >
+          <label
+            className="font-bold text-sm"
+            htmlFor="password"
+          >
+            Password 
+            <span
+              className="text-red-500 font-bold"
+            >
+              *
+            </span>
+            :
+             
+          </label>
+          <input
+            className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold  border-green-500 "
+            id="password"
+            name="password"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="New password"
+            required={true}
+            type="Password"
+          />
+          <div
+            className="text-xs py-1/2 text-red-500 opacity-0"
+          />
+        </div>
+        <div
+          className="relative w-full mb-2"
+        >
+          <label
+            className="font-bold text-sm"
+            htmlFor="password2"
+          >
+            Confirm password 
+            <span
+              className="text-red-500 font-bold"
+            >
+              *
+            </span>
+            :
+          </label>
+          <input
+            className="w-full rounded-md placeholder:text-sm placeholder:font-light  border-2 focus:outline-none px-2 py-1 font-bold 
+              border-green-500 
+              "
+            id="password2"
+            name="password2"
+            onBlur={[Function]}
+            onChange={[Function]}
+            placeholder="Confirm password"
+            required={true}
+            type="password"
+          />
+          <div
+            className="text-xs py-1/2 text-red-500 opacity-0"
+          />
+        </div>
+        <button
+          className="py-1 px-3 text-center bg-primary hover:bg-hover transition-all hover:transition-all uppercase text-white font-bold rounded-md"
+        >
+          SUBMIT
+        </button>
+      </form>
+    </ResetNewPassword>
+  </Router>
+</BrowserRouter>
+`;

--- a/src/server.js
+++ b/src/server.js
@@ -7,4 +7,9 @@ const port = process.env.PORT || 3000; // Heroku will need the PORT environment 
 
 app.use(express.static(join(__dirname, 'dist')));
 
+// Always ensure to load the react router to handle the routing
+app.use('*', (req, res) => {
+  return res.sendFile(join(__dirname, 'dist', 'index.html'));
+});
+
 app.listen(port, () => {});

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,13 @@
+export  const sleep = (ms, type)=>{
+    if (type==="reject") {
+        return new Promise((resolve, reject)=>{
+            setTimeout(reject, ms)
+        })
+    }
+    return new Promise(resolve=>{
+        setTimeout(resolve, ms||2000)
+    })
+
+}
+
+export default sleep

--- a/src/utils/test/sleep.test.js
+++ b/src/utils/test/sleep.test.js
@@ -1,0 +1,20 @@
+import sleep from '../sleep.js';
+
+describe('Utils test', () => {
+  it('Should resolve', async () => {
+    const promise = await sleep(2000);
+    expect(promise).toBe(undefined);
+  });
+  it('Should resolve', async () => {
+    const promise = await sleep();
+
+    expect(promise).toBe(undefined);
+  });
+  test('the fetch fails with an error', async () => {
+    try {
+      await sleep(2000, 'reject');
+    } catch (e) {
+      expect(e).toBe(undefined);
+    }
+  });
+});

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,7 +10,8 @@ module.exports = {
         primary: '#1B73E8',
         hover: '#053A80',
         hover2: '#f3f7fc',
-        background: '#fafafa'
+        background: '#fafafa',
+        hovercancel: '#9B1A1B'
       },
       boxShadow: {
         main: '0px 0px 6px 4px rgba(0, 0, 0, 0.1)'

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -2,7 +2,14 @@ import '@testing-library/jest-dom';
 import { configure as testLibraryConfigure } from '@testing-library/react';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { configure } from 'enzyme';
+import 'regenerator-runtime/runtime';
 
 testLibraryConfigure({ testIdAttribute: 'id' });
+
+jest.mock('react-toastify', () => {
+  const actual = jest.requireActual('react-toastify');
+  Object.assign(actual, { toast: jest.fn() });
+  return actual;
+});
 
 configure({ adapter: new Adapter() });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -8,7 +8,8 @@ const __dirname = path.dirname(__filename);
 const config = {
   entry: path.join(__dirname, 'src', 'index.js'),
   output: {
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/'
   },
   devServer: {
     static: {
@@ -17,7 +18,9 @@ const config = {
     historyApiFallback: true,
     compress: true,
     port: 3000,
-    watchFiles: ['./src/**/*.{js,jsx, css, scss}']
+    watchFiles: ['./src/**/*.{js,jsx, css, scss}'],
+    historyApiFallback: true,
+    hot: true
   },
   module: {
     rules: [


### PR DESCRIPTION
### What this PR do:
#### This PR adds:
- Add reset password routes
- Use react router to navigate the UI

#### This PR Fixes:
- The error of routing not working in development
- Add ability for the server to let react handle all routing 

### Description of Task to be completed
- [x]  Add reset password Form
- [x] Handle form submission
- [x] The user should be able to provide their email.
- [x] The driver or operator should be able to receive a reset password link in their email.
- [x] The driver or operator should be able to reset the password( i.e. provide a new password).
- [x] The driver or operator should be able to login with the new password.
- [x] Skeleton UIs/screen are/is shown when the page loads/is loading.
- [x] The page is responsive.
- [x] Appropriate error messages are displayed on unsuccessful attempts
- [x] Tests are written

### How should this be manually tested?
```
// with github cli:
git fetch
gh pr checkout 18 // or git checkout ft-create-reset-pass-page-cp-31
npm install
npm start
// open browser and start with login. 
// Instructions are on the page
```
### Any background context you want to provide?
As **a driver and operator**, I want to be able to reset my password in case I forgot it so that I can log in to the app.
### What are the relevant pivotal tracker stories?
- [#cp31](https://trello.com/c/19jzoCoE)
### Screenshots (if appropriate)