### PR TITLE
Styled options in chrome

### DIFF
--- a/src/pages/TrackingPage.js
+++ b/src/pages/TrackingPage.js
@@ -109,7 +109,7 @@ const TrackingPage = () => {
                 <option
                   value={option.name}
                   key={option.name}
-                  className="cursor-pointer"
+                  className="cursor-pointer bg-transparent font-bold font-raleway disabled:text-gray-400 disabled:bg-gray-100"
                 >
                   {option.name}
                 </option>
@@ -133,7 +133,7 @@ const TrackingPage = () => {
                 <option
                   value={option.name}
                   key={option.name}
-                  className="cursor-pointer"
+                  className="cursor-pointer bg-transparent hover:bg-primary font-raleway font-bold disabled:text-gray-400 disabled:bg-gray-100"
                 >
                   {option.name}
                 </option>


### PR DESCRIPTION
### What this PR does:
Minor improvements to the styling of options

### Background context
The styled options only works in chrome. As of now styling options does not work with Firefox due to a multi-process bug.

Tagged: @samuel-shyaka-dus 