### PR TITLE
#CP-34 feat: assign buses to routes integration

### DIFF
--- a/src/Modals/AssignRoute.js
+++ b/src/Modals/AssignRoute.js
@@ -1,0 +1,148 @@
+import { ButtonLoading, PrimaryButton } from '@components/Button.js';
+import axios from '@utils/Api.js';
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import Swal from 'sweetalert2';
+
+export const assignRouteToBus = async (busInfo, driverInfo) => {
+  await axios.patch('/buses/' + busInfo.id, { driver: driverInfo.name });
+  await axios.patch('/drivers/' + driverInfo.id, {
+    assigned_bus: busInfo.plateNumber
+  });
+};
+
+export const AssignRouteModal = ({ handleClose }) => {
+  const navigate = useNavigate();
+  const [loading, setloading] = useState(false);
+  const location = useLocation();
+  console.log(location.state)
+  const [createButton, setCreateButton] = useState({
+    open: false,
+    plate: null
+  });
+  const { register, handleSubmit } = useForm();
+  const { plateNumber, busType, seats, route, id } = location?.state;
+  const onSubmit = async (data) => {
+    const inputPlate = data.plate.toUpperCase();
+    try {
+      setloading(true);
+      const response = await axios.get('/buses/', {
+        params: { plateNumber: inputPlate }
+      });
+      const bus = response.data[0];
+      if (bus) {
+        setCreateButton({ open: false, plate: null });
+        if (bus.driver) {
+          Swal.fire({
+            title: 'Are you sure?',
+            text: 'This bus already have a driver!',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Yes, change!'
+          }).then(async (result) => {
+            if (result.isConfirmed) {
+              await assignRouteToBus(bus, location.state);
+              const response = await axios.get('/drivers/', {
+                params: { assigned_bus: bus.plateNumber }
+              });
+              const driver = response.data[0];
+              await axios.patch('/drivers/' + driver.id, {
+                assigned_bus: null
+              });
+              Swal.fire(
+                'Changed!',
+                'The bus has been assigned a new driver.',
+                'success'
+              );
+            }
+          });
+        } else {
+          await assignRouteToBus(bus, location.state);
+          toast('New driver assigned successfully', { type: 'success' });
+          navigate('/dashboard/management');
+        }
+      } else {
+        toast('Bus was not found', { type: 'error' });
+        setCreateButton({ open: true, plate: inputPlate });
+      }
+    } catch (error) {
+      toast('Something went wrong on our end');
+    } finally {
+      setloading(false);
+    }
+  };
+
+  return (
+    <div className="font-raleway w-fit px-8 py-2">
+      <h1 className="font-bold">Driver Info</h1>
+      <hr />
+      <ul>
+        <li>
+          <span>Plate: </span>
+          <b>{plateNumber}</b>
+        </li>
+        <li>
+          <span>Type: </span>
+          <b>{busType}</b>
+        </li>
+        <li>
+          <span>Seats: </span>
+          <b>{seats}</b>
+        </li>
+        <li>
+          <span>Assigned route: </span>
+          <b>{route}</b>
+        </li>
+      </ul>
+      <hr />
+      <div>
+        <form
+          id="assign-form"
+          action="#23"
+          className="py-2"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <label htmlFor="bus" className="block font-raleway">
+            Route:{' '}
+          </label>
+          <input
+            className="bg-gray-300 my-2 border px-2 py-1 rounded-sm placeholder:font-raleway uppercase"
+            required
+            type="text"
+            id="bus-plate"
+            name="plate"
+            placeholder="RAB1000"
+            {...register('route', {
+              required: 'The route is required'
+            })}
+          />
+          {loading ? (
+            <ButtonLoading name={'Searching...'} />
+          ) : (
+            <PrimaryButton type={'submit'} name={'Search'}></PrimaryButton>
+          )}
+
+          <div>
+            {createButton.open ? (
+              <div className="pt-3">
+                <div className="font-raleway">
+                  Bus with {createButton.plate} was not found
+                </div>
+                <Link to="/dashboard/management/bus/register">
+                  <PrimaryButton name={`Create new "${createButton.plate}"`} />
+                </Link>
+              </div>
+            ) : (
+              ''
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+export default AssignRouteModal;

--- a/src/components/dropdowns/BusManagement.js
+++ b/src/components/dropdowns/BusManagement.js
@@ -4,7 +4,25 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { ButtonLoading } from '../Button.js';
 
+busType: "Minibus"
+company: "KBS"
+driver: null
+id: 5
+plateNumber: "RAT230A"
+route: null
+seats: "50"
+
 const BusManagement = ({ row }) => {
+  const { plateNumber, busType, seats, driver, route, company, id } = row.original;
+  const data = {
+    plateNumber,
+    busType,
+    seats,
+    driver,
+    route,
+    company,
+    id
+  };
   const navigate = useNavigate();
   const [loading, setloading] = useState(false);
   const handleEdit = (busInfo) => {
@@ -25,6 +43,11 @@ const BusManagement = ({ row }) => {
       setloading(false);
     }
   };
+  const handleAssignRoute = (busInfo) => {
+    navigate(`/dashboard/modal/bus/assign/${plateNumber}`, {
+      state: data
+    });
+  }
 
   const handleChange = (e) => {
     switch (e.target.value) {
@@ -32,6 +55,8 @@ const BusManagement = ({ row }) => {
         return handleEdit(row.original);
       case 'delete':
         return handleDelete(row.original.id);
+      case 'assign_route':
+        return handleAssignRoute(row.original);
     }
   };
   return (
@@ -47,6 +72,9 @@ const BusManagement = ({ row }) => {
           className="py-1 px-3 font-rale font-bold bg-transparent border rounded-sm"
         >
           <option hidden={true}>Manage</option>
+          <option className="cursor-pointer" value="assign_route">
+            Assign Route
+          </option>
           <option className="cursor-pointer" value="edit">
             Edit
           </option>

--- a/src/containers/ModalRoutes.js
+++ b/src/containers/ModalRoutes.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import AssignBusModal from '../Modals/AssignBus.js';
+import AssignRouteModal from '../Modals/AssignRoute.js';
 import ChangeRole from '../Modals/ChangeRole.js';
 import RouteView from '../pages/routes/RouteView.js';
 import UpdateBus from '../pages/UpdateBus.js';
@@ -23,6 +24,10 @@ function ModalRoutes() {
           <Route
             path="driver/assign/:id"
             element={<AssignBusModal handleClose={handleBack} />}
+          />
+          <Route
+            path="bus/assign/:code"
+            element={<AssignRouteModal handleClose={handleBack} />}
           />
           <Route path="bus/update/:id" element={<UpdateBus />} />
           <Route path="permission/change/:id" element={<ChangeRole />} />


### PR DESCRIPTION
#### What does this PR do?
Enable an operator to assign a bus to a route so that the bus can only be utilized in that route. 

#### Description of the tasks to be completed
- [x] The operator should be able to assign a bus to a route.
- [x] The operator should be able to see a paginated list of buses to routes assignments.
- [x] All Requests should be sent to the back-end and return appropriate responses
- [x] Appropriate error messages are displayed on unsuccessful attempts
- [x] The system should work with real data from the database

#### How should this be manually tested?
```js
git checkout ft-assign-buses-to-routes-cp-34
git fetch
npm install
npm start
```
> **Testing the feature**
```
>> Login as an operator
>> Click the management tab
>> Click Buses
>> Click manage dropdown button next to the bus you want to assign a route to
>> Click Assign route
>> Chose the route
>> Click Assign
```
#### Pre-requisites:

- Clone the project

#### Relevant trello story:
[#CP-34](https://trello.com/c/30VNVOuG/34-assign-buses-to-routes)