### PR TITLE
#CP-34 feat: assign buses to routes integration

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,2 +1,9 @@
-import mockAxios from 'jest-mock-axios';
+const mockAxios = jest.genMockFromModule('axios');
+mockAxios.create = jest.fn(() => mockAxios);
+mockAxios.get = jest.fn(() => Promise.resolve(
+    {
+        
+        data: {data: []}
+    }
+))
 export default mockAxios;

--- a/src/Modals/AssignRoute.js
+++ b/src/Modals/AssignRoute.js
@@ -1,0 +1,145 @@
+import { ButtonLoading, PrimaryButton } from '@components/Button.js';
+import { axiosBase as axios } from '@utils/Api.js';
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import Swal from 'sweetalert2';
+
+export const assignRouteToBus = async (data) => {
+  try {
+    await axios.post(`/bus-to-routes/${data.plateNumber}/${data.route}`);
+    return true;
+  } catch(error) {
+    toast('Something went wrong on our end');
+  }
+};
+
+export const AssignRouteModal = ({ handleClose }) => {
+  const navigate = useNavigate();
+  const [routes, setRoutes] = useState()
+  const [loading, setloading] = useState(false);
+  const location = useLocation();
+  const { plateNumber, busType, seats, route, id } = location?.state;
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    const data = {
+      plateNumber: plateNumber,
+      route: e.target.route.value
+    }
+    try {
+      setloading(true);
+      if (route) {
+        Swal.fire({
+          title: 'Are you sure?',
+          text: 'This bus already have a route!',
+          icon: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#3085d6',
+          cancelButtonColor: '#d33',
+          confirmButtonText: 'Yes, Assign route!'
+        }).then(async (result) => {
+          if (result.isConfirmed) {
+            await assignRouteToBus(data);
+            Swal.fire(
+              'Done!',
+              'The bus has been assigned a new route.',
+              'success'
+            ).then(() => {
+              navigate('/dashboard/management');
+            });
+          }
+        });
+      } else {
+        await assignRouteToBus(data);
+        toast('The bus has been assigned a new route.', { type: 'success' });
+        navigate('/dashboard/management');
+      }
+
+    } catch (error) {
+      toast(error?.response?.data?.data?.message);
+    } finally {
+      setloading(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setloading(true);
+        const response = await axios.get('/routes');
+        setRoutes(response.data.data);
+      }
+      catch (error) {
+        toast(error?.response?.data?.data?.message);
+      } finally {
+        setloading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <div className="font-raleway w-fit px-8 py-2">
+      <h1 className="font-bold">Bus Info</h1>
+      <hr />
+      <ul>
+        <li>
+          <span>Plate: </span>
+          <b>{plateNumber}</b>
+        </li>
+        <li>
+          <span>Type: </span>
+          <b>{busType}</b>
+        </li>
+        <li>
+          <span>Seats: </span>
+          <b>{seats}</b>
+        </li>
+        <li>
+          <span>Assigned route: </span>
+          <b>{route?.origin} - {route?.destination}</b>
+        </li>
+      </ul>
+      <hr />
+      <div>
+        <form
+          id="assign-form"
+          action="#23"
+          className="py-2"
+          onSubmit={onSubmit}
+        >
+          <label htmlFor="bus" className="block font-raleway">
+            Route:{' '}
+          </label>
+          <select
+            className="bg-gray-300 my-2 border px-2 py-1 rounded-sm placeholder:font-raleway uppercase"
+            required
+            type="text"
+            id="bus-route"
+            name="route"
+          >
+            <option id="origin-select">Select route</option>
+            {routes && routes.map((route) => {
+              return (
+                <option
+                  value={route.code}
+                  key={route.code}
+                  className="cursor-pointer bg-transparent font-bold font-raleway disabled:text-gray-400 disabled:bg-gray-100"
+                >
+                  {route.origin} - {route.destination}
+                </option>
+              );
+            })}
+          </select>
+          {loading ? (
+            <ButtonLoading name={'Loading...'} />
+          ) : (
+            <PrimaryButton type={'submit'} name={'Assign'}></PrimaryButton>
+          )}
+
+        </form>
+      </div>
+    </div>
+  );
+};
+export default AssignRouteModal;

--- a/src/Modals/tests/AssignRoute.test.js
+++ b/src/Modals/tests/AssignRoute.test.js
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import AssignRouteModal, { assignRouteToBus } from '../AssignRoute.js';
+
+const mockUseLocationValue = {
+  pathname: '/testroute',
+  search: '',
+  hash: '',
+  state: {
+    plateNumber: 'RAB162H',
+    busType: 'coaster',
+    seats: 25,
+    route: {
+        origin: "Nyabugogo",
+        destination: "Remera"
+    }
+  }
+};
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockImplementation(() => {
+    return mockUseLocationValue;
+  })
+}));
+
+describe('Modal tests', () => {
+  const event = {
+    target: {
+      route: { value: 'some value' }
+    }
+  };
+  it('It should test the onSubmit function', () => {
+    const onSubmit = jest.fn();
+    const component = mount(
+      <MemoryRouter>
+        <AssignRouteModal onSubmit={onSubmit()} />
+      </MemoryRouter>
+    );
+    const form = component.find('form');
+    form.simulate('submit', event);
+    expect(onSubmit).toBeCalledTimes(1);
+  });
+  it('Should render the assign modal', async () => {
+    const onSubmitMock = jest.fn();
+    const handleCloseMock = jest.fn();
+    
+    const elem = render(
+      <MemoryRouter>
+        <AssignRouteModal
+          onSubmit={onSubmitMock}
+          handleClose={handleCloseMock}
+        ></AssignRouteModal>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByTestId('bus-route'), {
+        target: {
+            value: 'RN45'
+        }
+    });
+
+    fireEvent.submit(screen.getByTestId('assign-form'), {
+      target: {
+        route: { value: 'some value' }
+      }
+    });
+    
+    expect(elem).toMatchSnapshot();
+  });
+});
+

--- a/src/Modals/tests/__snapshots__/AssignRoute.test.js.snap
+++ b/src/Modals/tests/__snapshots__/AssignRoute.test.js.snap
@@ -1,0 +1,378 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Modal tests Should render the assign modal 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body
+    class="swal2-shown swal2-height-auto"
+  >
+    <div
+      aria-hidden="true"
+    >
+      <div
+        class="font-raleway w-fit px-8 py-2"
+      >
+        <h1
+          class="font-bold"
+        >
+          Bus Info
+        </h1>
+        <hr />
+        <ul>
+          <li>
+            <span>
+              Plate: 
+            </span>
+            <b>
+              RAB162H
+            </b>
+          </li>
+          <li>
+            <span>
+              Type: 
+            </span>
+            <b>
+              coaster
+            </b>
+          </li>
+          <li>
+            <span>
+              Seats: 
+            </span>
+            <b>
+              25
+            </b>
+          </li>
+          <li>
+            <span>
+              Assigned route: 
+            </span>
+            <b>
+              Nyabugogo
+               - 
+              Remera
+            </b>
+          </li>
+        </ul>
+        <hr />
+        <div>
+          <form
+            action="#23"
+            class="py-2"
+            id="assign-form"
+          >
+            <label
+              class="block font-raleway"
+              for="bus"
+            >
+              Route:
+               
+            </label>
+            <select
+              class="bg-gray-300 my-2 border px-2 py-1 rounded-sm placeholder:font-raleway uppercase"
+              id="bus-route"
+              name="route"
+              required=""
+              type="text"
+            >
+              <option
+                id="origin-select"
+              >
+                Select route
+              </option>
+            </select>
+            <button
+              class="bg-primary rounded-md text-white font-bold font-raleway py-2 px-3 hover:bg-hover transition-all block hover:transition-all"
+              type="submit"
+            >
+              Assign
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+    <div
+      class="swal2-container swal2-center swal2-backdrop-show"
+    >
+      <div
+        aria-describedby="swal2-html-container"
+        aria-labelledby="swal2-title"
+        aria-live="assertive"
+        aria-modal="true"
+        class="swal2-popup swal2-modal swal2-icon-warning"
+        role="dialog"
+        style="opacity: 0 !important; display: grid;"
+        tabindex="-1"
+      >
+        <button
+          aria-label="Close this dialog"
+          class="swal2-close"
+          style="display: none;"
+          type="button"
+        >
+          ×
+        </button>
+        <ul
+          class="swal2-progress-steps"
+          style="display: none;"
+        />
+        <div
+          class="swal2-icon swal2-warning swal2-icon-show"
+          style="display: flex;"
+        >
+          <div
+            class="swal2-icon-content"
+          >
+            !
+          </div>
+        </div>
+        <img
+          class="swal2-image"
+          style="display: none;"
+        />
+        <h2
+          class="swal2-title"
+          id="swal2-title"
+          style="display: block;"
+        >
+          Are you sure?
+        </h2>
+        <div
+          class="swal2-html-container"
+          id="swal2-html-container"
+          style="display: block;"
+        >
+          This bus already have a route!
+        </div>
+        <input
+          class="swal2-input"
+          style="display: none;"
+        />
+        <input
+          class="swal2-file"
+          style="display: none;"
+          type="file"
+        />
+        <div
+          class="swal2-range"
+          style="display: none;"
+        >
+          <input
+            type="range"
+          />
+          <output />
+        </div>
+        <select
+          class="swal2-select"
+          style="display: none;"
+        />
+        <div
+          class="swal2-radio"
+          style="display: none;"
+        />
+        <label
+          class="swal2-checkbox"
+          for="swal2-checkbox"
+          style="display: none;"
+        >
+          <input
+            type="checkbox"
+          />
+          <span
+            class="swal2-label"
+          />
+        </label>
+        <textarea
+          class="swal2-textarea"
+          style="display: none;"
+        />
+        <div
+          class="swal2-validation-message"
+          id="swal2-validation-message"
+          style="display: none;"
+        />
+        <div
+          class="swal2-actions"
+          style="display: flex;"
+        >
+          <div
+            class="swal2-loader"
+          />
+          <button
+            aria-label=""
+            class="swal2-confirm swal2-styled swal2-default-outline"
+            style="display: inline-block; background-color: rgb(48, 133, 214);"
+            type="button"
+          >
+            Yes, Assign route!
+          </button>
+          <button
+            aria-label=""
+            class="swal2-deny swal2-styled"
+            style="display: none;"
+            type="button"
+          >
+            No
+          </button>
+          <button
+            aria-label=""
+            class="swal2-cancel swal2-styled swal2-default-outline"
+            style="display: inline-block; background-color: rgb(221, 51, 51);"
+            type="button"
+          >
+            Cancel
+          </button>
+        </div>
+        <div
+          class="swal2-footer"
+          style="display: none;"
+        />
+        <div
+          class="swal2-timer-progress-bar-container"
+        >
+          <div
+            class="swal2-timer-progress-bar"
+            style="display: none;"
+          />
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div
+    aria-hidden="true"
+  >
+    <div
+      class="font-raleway w-fit px-8 py-2"
+    >
+      <h1
+        class="font-bold"
+      >
+        Bus Info
+      </h1>
+      <hr />
+      <ul>
+        <li>
+          <span>
+            Plate: 
+          </span>
+          <b>
+            RAB162H
+          </b>
+        </li>
+        <li>
+          <span>
+            Type: 
+          </span>
+          <b>
+            coaster
+          </b>
+        </li>
+        <li>
+          <span>
+            Seats: 
+          </span>
+          <b>
+            25
+          </b>
+        </li>
+        <li>
+          <span>
+            Assigned route: 
+          </span>
+          <b>
+            Nyabugogo
+             - 
+            Remera
+          </b>
+        </li>
+      </ul>
+      <hr />
+      <div>
+        <form
+          action="#23"
+          class="py-2"
+          id="assign-form"
+        >
+          <label
+            class="block font-raleway"
+            for="bus"
+          >
+            Route:
+             
+          </label>
+          <select
+            class="bg-gray-300 my-2 border px-2 py-1 rounded-sm placeholder:font-raleway uppercase"
+            id="bus-route"
+            name="route"
+            required=""
+            type="text"
+          >
+            <option
+              id="origin-select"
+            >
+              Select route
+            </option>
+          </select>
+          <button
+            class="bg-primary rounded-md text-white font-bold font-raleway py-2 px-3 hover:bg-hover transition-all block hover:transition-all"
+            type="submit"
+          >
+            Assign
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/BusesTable.js
+++ b/src/components/BusesTable.js
@@ -13,8 +13,10 @@ const DriverLink = ({ row }) => {
 };
 
 const RouteLink = ({ row }) => {
-  if (row.route) {
-    return <div>{row.route}</div>;
+  console.log(row)
+  if (row.routeId) {
+
+    return <div>{row.route.origin} - {row.route.destination}</div>;
   }
   return <div className="text-red">No route assigned</div>;
 };
@@ -53,10 +55,14 @@ const BusesTable = () => {
     const fetchData = async () => {
       try {
         setloading(true);
-        const response = await axios.get('/buses');
+        const response = await axios.get('/buses', {
+          params: {
+            relation: true
+          }
+        });
         setbuses(response.data.data);
       } catch (error) {
-        toast(error.message, { type: 'error' });
+        toast(error?.response?.data?.data?.message);
       } finally {
         setloading(false);
       }

--- a/src/components/dropdowns/BusManagement.js
+++ b/src/components/dropdowns/BusManagement.js
@@ -8,6 +8,16 @@ import { ButtonLoading } from '../Button.js';
 /* istanbul ignore next */
 
 const BusManagement = ({ row }) => {
+  const { plateNumber, busType, seats, driver, route, company, id } = row.original;
+  const data = {
+    plateNumber,
+    busType,
+    seats,
+    driver,
+    route,
+    company,
+    id
+  };
   const navigate = useNavigate();
   const [loading, setloading] = useState(false);
   const handleEdit = (busInfo) => {
@@ -42,12 +52,20 @@ const BusManagement = ({ row }) => {
       }
     }
   };
+  const handleAssignRoute = (busInfo) => {
+    navigate(`/dashboard/modal/bus/assign/${plateNumber}`, {
+      state: data
+    });
+  }
+
   const handleChange = (e) => {
     switch (e.target.value) {
       case 'edit':
         return handleEdit(row.original);
       case 'delete':
         return handleDelete(row.original);
+      case 'assign_route':
+        return handleAssignRoute(row.original);
     }
   };
   return (
@@ -63,6 +81,9 @@ const BusManagement = ({ row }) => {
           className="py-1 px-3 font-rale font-bold bg-transparent border rounded-sm"
         >
           <option hidden={true}>Manage</option>
+          <option className="cursor-pointer" value="assign_route">
+            Assign Route
+          </option>
           <option className="cursor-pointer" value="edit">
             Edit
           </option>

--- a/src/components/dropdowns/tests/__snapshots__/BusManagement.test.js.snap
+++ b/src/components/dropdowns/tests/__snapshots__/BusManagement.test.js.snap
@@ -25,6 +25,12 @@ Object {
           </option>
           <option
             class="cursor-pointer"
+            value="assign_route"
+          >
+            Assign Route
+          </option>
+          <option
+            class="cursor-pointer"
             value="edit"
           >
             Edit
@@ -209,6 +215,12 @@ Object {
         </option>
         <option
           class="cursor-pointer"
+          value="assign_route"
+        >
+          Assign Route
+        </option>
+        <option
+          class="cursor-pointer"
           value="edit"
         >
           Edit
@@ -298,6 +310,12 @@ Object {
             hidden=""
           >
             Manage
+          </option>
+          <option
+            class="cursor-pointer"
+            value="assign_route"
+          >
+            Assign Route
           </option>
           <option
             class="cursor-pointer"
@@ -484,6 +502,12 @@ Object {
         </option>
         <option
           class="cursor-pointer"
+          value="assign_route"
+        >
+          Assign Route
+        </option>
+        <option
+          class="cursor-pointer"
           value="edit"
         >
           Edit
@@ -569,6 +593,12 @@ exports[`BusManagement Should render bus management page 1`] = `
     </option>
     <option
       className="cursor-pointer"
+      value="assign_route"
+    >
+      Assign Route
+    </option>
+    <option
+      className="cursor-pointer"
       value="edit"
     >
       Edit
@@ -604,6 +634,12 @@ Object {
           </option>
           <option
             class="cursor-pointer"
+            value="assign_route"
+          >
+            Assign Route
+          </option>
+          <option
+            class="cursor-pointer"
             value="edit"
           >
             Edit
@@ -632,6 +668,12 @@ Object {
           hidden=""
         >
           Manage
+        </option>
+        <option
+          class="cursor-pointer"
+          value="assign_route"
+        >
+          Assign Route
         </option>
         <option
           class="cursor-pointer"

--- a/src/containers/ModalRoutes.js
+++ b/src/containers/ModalRoutes.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import AssignBusModal from '../Modals/AssignBus.js';
+import AssignRouteModal from '../Modals/AssignRoute.js';
 import ChangeRole from '../Modals/ChangeRole.js';
 import RouteView from '../pages/routes/RouteView.js';
 import UpdateBus from '../pages/UpdateBus.js';
@@ -23,6 +24,10 @@ function ModalRoutes() {
           <Route
             path="driver/assign/:id"
             element={<AssignBusModal handleClose={handleBack} />}
+          />
+          <Route
+            path="bus/assign/:code"
+            element={<AssignRouteModal handleClose={handleBack} />}
           />
           <Route path="bus/update/:id" element={<UpdateBus />} />
           <Route path="permission/change/:id" element={<ChangeRole />} />


### PR DESCRIPTION
#### What does this PR do?
Enable an operator to assign a bus to a route so that the bus can only be utilized in that route. 

#### Description of the tasks to be completed
- [x] The operator should be able to assign a bus to a route.
- [x] The operator should be able to see a paginated list of buses to routes assignments.
- [x] All Requests should be sent to the back-end and return appropriate responses
- [x] Appropriate error messages are displayed on unsuccessful attempts
- [x] The system should work with real data from the database

#### How should this be manually tested?
```js
git checkout ft-assign-buses-to-routes-integration-cp-34
git fetch
npm install
npm start
```
> **Testing the feature**
```
>> Login as an operator
>> Click the management tab
>> Click Buses
>> Click manage dropdown button next to the bus you want to assign a route to
>> Click Assign route
>> Chose the route
>> Click Assign
```
#### Pre-requisites:

- Clone the project

#### Relevant trello story:
[#CP-34](https://trello.com/c/30VNVOuG/34-assign-buses-to-routes)